### PR TITLE
chore(db):

### DIFF
--- a/cleantrac_project/db_routers.py
+++ b/cleantrac_project/db_routers.py
@@ -1,0 +1,47 @@
+"""Database router to send all reads/writes for the `receiving` app to the
+`traceability_source` Postgres database.  This keeps the external table fully
+isolated from Django's default DB and prevents accidental writes to SQLite in
+local dev.
+
+Any additional legacy apps that should point at the same database can be added
+to the `app_labels` set below.
+"""
+from typing import Optional, Type
+from django.db import models
+
+
+class TraceabilityRouter:  # pylint: disable=too-few-public-methods
+    """Route database operations for the `receiving` app."""
+
+    app_labels = {"receiving"}
+
+    # --- Primary helpers -------------------------------------------------
+    def _is_traceability_model(self, model: Type[models.Model]) -> bool:  # noqa: D401
+        """Return True if the given model belongs to an app that should hit the
+        traceability_source DB. The check is done via the app label to avoid
+        circular-import headaches.
+        """
+
+        return model._meta.app_label in self.app_labels  # type: ignore[attr-defined]
+
+    # --- Django router API ----------------------------------------------
+    def db_for_read(self, model: Type[models.Model], **hints) -> Optional[str]:
+        if self._is_traceability_model(model):
+            return "traceability_source"
+        return None
+
+    # Writes are extremely rare (ideally never) but route the same way so that
+    # admin/manual data-fix scripts don't fall back to the wrong database.
+    db_for_write = db_for_read  # type: ignore[assignment]
+
+    def allow_relation(self, obj1, obj2, **hints):  # noqa: D401
+        """Prevent cross-DB FK relations that Django cannot enforce."""
+        if {obj1._state.db, obj2._state.db} <= {"traceability_source", "default"}:
+            return True
+        return None
+
+    def allow_migrate(self, db: str, app_label: str, model_name: str | None = None, **hints):
+        """Block migrations for traceability models – the table already exists."""
+        if app_label in self.app_labels:
+            return False
+        return None

--- a/core/management/commands/check_traceability_db.py
+++ b/core/management/commands/check_traceability_db.py
@@ -1,0 +1,42 @@
+"""Health-check command to verify connectivity to the external traceability
+(Postgres) database and that the expected number of rows are present in
+`received_products`.  Intended for use in CI/CD pipelines and manual
+troubleshooting.
+
+Usage::
+
+    python manage.py check_traceability_db [--expected 700]
+
+The command exits with status-code 1 if the query fails or if the row count is
+below the expected threshold.
+"""
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DatabaseError
+
+from core.receiving_models import ReceivingRecord
+
+
+class Command(BaseCommand):
+    help = "Verify traceability_source DB connectivity and row count."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--expected",
+            type=int,
+            default=1,
+            help="Fail if row count is less than this value (default: 1)",
+        )
+
+    def handle(self, *args, **options):  # noqa: D401
+        expected = options["expected"]
+        try:
+            count = ReceivingRecord.objects.using("traceability_source").count()
+        except DatabaseError as exc:
+            raise CommandError(f"Could not query traceability_source DB: {exc}") from exc
+
+        if count < expected:
+            raise CommandError(
+                f"Row count {count} is below expected minimum {expected}. Check data import."
+            )
+
+        self.stdout.write(self.style.SUCCESS(f"Traceability DB OK – received_products rows: {count}"))


### PR DESCRIPTION
route receiving app to RDS + add traceability health-check

• Added TraceabilityRouter to force all receiving models to use the
  traceability_source Postgres DB
• Registered router in settings.py
• New management command `check_traceability_db` verifies connectivity
  and row count (for CI/CD)